### PR TITLE
implement private certificate renewal

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -29,8 +29,3 @@ jobs:
       docker_images: |
         balena/cert-manager,
         ghcr.io/balena-io/cert-manager
-      required_status_checks: >
-        [
-          "Flowzone / All tests",
-          "Flowzone / All jobs"
-        ]


### PR DESCRIPTION
resolves: https://github.com/balena-io/cert-manager/issues/39

.. check if the private certificate chain is near expiry and renew
.. don't touch customer supplied certificates
.. print certificate issuer and subject for troubleshooting (e.g. customer provided certificates)