### PR TITLE
Drop DSA as modern ssh-keygen no longer supports it

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ signal that the volume contains complete set of PKI assets:
 	│   ├── api.{{tld}}.pem
 	│   ├── ca-bundle.{{tld}}.pem
 	│   ├── devices.{{tld}}.authorized_keys
-	│   ├── devices.{{tld}}.dsa.key
-	│   ├── devices.{{tld}}.dsa.key.pub
 	│   ├── devices.{{tld}}.ecdsa.key
 	│   ├── devices.{{tld}}.ecdsa.key.pub
 	│   ├── devices.{{tld}}.ed25519.key
@@ -30,8 +28,6 @@ signal that the volume contains complete set of PKI assets:
 	│   ├── devices.{{tld}}.rsa.key.pub
 	│   ├── dhparam.{{tld}}.pem
 	│   ├── git.{{tld}}.authorized_keys
-	│   ├── git.{{tld}}.dsa.key
-	│   ├── git.{{tld}}.dsa.key.pub
 	│   ├── git.{{tld}}.ecdsa.key
 	│   ├── git.{{tld}}.ecdsa.key.pub
 	│   ├── git.{{tld}}.ed25519.key
@@ -39,8 +35,6 @@ signal that the volume contains complete set of PKI assets:
 	│   ├── git.{{tld}}.rsa.key
 	│   ├── git.{{tld}}.rsa.key.pub
 	│   ├── proxy.{{tld}}.authorized_keys
-	│   ├── proxy.{{tld}}.dsa.key
-	│   ├── proxy.{{tld}}.dsa.key.pub
 	│   ├── proxy.{{tld}}.ecdsa.key
 	│   ├── proxy.{{tld}}.ecdsa.key.pub
 	│   ├── proxy.{{tld}}.ed25519.key

--- a/entry.sh
+++ b/entry.sh
@@ -130,11 +130,11 @@ function generate_ssh_keys {
 	[[ -n "${tld}" ]] || return
 
 	if [[ -d "${CERTS}/private" ]]; then
-		# (DSA) https://security.stackexchange.com/a/112818/201462
-		for algo in rsa ecdsa dsa ed25519; do
+		rm -f "${CERTS}/private/"*.dsa.key*
+		for algo in rsa ecdsa ed25519; do
 			key="${CERTS}/private/${cn}.${tld}.${algo}.key"
 			if ! [[ -s "${key}" ]]; then
-				# cfssl doesn't handle dsa and ed25519 key formats
+				# cfssl doesn't handle ed25519 key format
 				ssh-keygen -f "${key}" -t "${algo}" -N "" -m PEM &&
 					chmod 0600 "${key}"
 			fi


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Console-pod-not-coming-online-209